### PR TITLE
Updated doc URLs from /cp/ to /control-panel/ path

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Settings/SecurityPrivacy.php
+++ b/system/ee/ExpressionEngine/Controller/Settings/SecurityPrivacy.php
@@ -61,7 +61,7 @@ class SecurityPrivacy extends Settings
                 array(
                     'title' => 'share_analytics',
                     'desc' => 'share_analytics_desc',
-                    'desc' => sprintf(lang('share_analytics_desc'), ee()->cp->masked_url(DOC_URL . 'cp/settings/security-privacy.html#share-analytics-with-the-expressionengine-development-team')),
+                    'desc' => sprintf(lang('share_analytics_desc'), ee()->cp->masked_url(DOC_URL . 'control-panel/settings/security-privacy.html#share-analytics-with-the-expressionengine-development-team')),
                     'fields' => array(
                         'share_analytics' => array(
                             'type' => 'yes_no'
@@ -79,7 +79,7 @@ class SecurityPrivacy extends Settings
                 ),
                 array(
                     'title' => 'cookie_path',
-                    'desc' => sprintf(lang('cookie_path_desc'), ee()->cp->masked_url(DOC_URL . 'cp/settings/security-privacy.html#path')),
+                    'desc' => sprintf(lang('cookie_path_desc'), ee()->cp->masked_url(DOC_URL . 'control-panel/settings/security-privacy.html#path')),
                     'fields' => array(
                         'cookie_path' => array('type' => 'text')
                     )


### PR DESCRIPTION
## Overview
Updated the EE Doc paths on the System Settings > Security & Privacy page in two places: 
- **providing analytics, diagnostic, and usage information.** (under Share analytics with the ExpressionEngine Development Team?)
- **(more info)** (under Cookie Settings > Path)

Previous URLs pointed to:  
.../cp/settings/...

Updated URLs to: 
.../control-panel/settings/...
